### PR TITLE
build(npm): update node compability up to `v8.x`

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
   "version": "2.0.0-beta.8",
   "license": "MIT",
   "engines": {
-    "node": ">= 5.4.1 < 7"
+    "node": ">= 5.4.1 <= 8"
   },
   "dependencies": {
     "@angular/cdk": "^2.0.0-beta.8",


### PR DESCRIPTION
The supported version of node.js has been increased to v8.x by this PR.

Fixes #357